### PR TITLE
Add an option to highlight trailing whitespace

### DIFF
--- a/c.nanorc
+++ b/c.nanorc
@@ -36,4 +36,4 @@ color brightblue "//.*"
 color brightblue start="/\*" end="\*/"
 
 ## Trailing whitespace
-color ,green "[[:space:]]+$"
+#color ,green "[[:space:]]+$"


### PR DESCRIPTION
Hi there! I've been using your syntax highlighting file, but you don''t seem to have included highlighting of trailing whitespace, which is present in the default file at /usr/share/nano/c.nanorc. I'm not sure if it was deliberately left out, but I thought that it'd be good to have the option in the file.
