### PR TITLE
Minor improvements to sh.nanorc

### DIFF
--- a/sh.nanorc
+++ b/sh.nanorc
@@ -1,6 +1,7 @@
 ## Here is an example for Bourne shell scripts.
 ##
-syntax "sh" "\.sh$" "Makefile" "\.bashrc" "bashrc" "\.bash_aliases" "bash_aliases" "\.bash_profile" "bash_profile"
+syntax "sh" "\.sh$" "\.bashrc" "bashrc" "\.bash_aliases" "bash_aliases" "\.bash_functions" "bash_functions" "\.bash_profile" "bash_profile"
+header "^#!.*/(ba)?sh"
 icolor brightgreen "^[0-9A-Z_]+\(\)"
 color green "\<(case|do|done|elif|else|esac|exit|fi|for|function|if|in|local|read|return|select|shift|then|time|until|while)\>"
 color green "(\{|\}|\(|\)|\;|\]|\[|`|\\|\$|<|>|!|=|&|\|)"


### PR DESCRIPTION
- Removed "makefile" (it has its own highlighting)
- Added header filter to detect files without an extension
- Added .bash_functions as a "known file"
