### PR TITLE
Fixes #43: html.nanorc yellow regex is greedy and matches all quotes until the final quote.

### DIFF
--- a/html.nanorc
+++ b/html.nanorc
@@ -3,5 +3,5 @@
 syntax "html" "\.htm[l]?$"
 color brightblue start="<" end=">"
 color red "&[^;[[:space:]]]*;"
-color yellow "".*"|qq\|.*\|"
+color yellow ""[^"]*"|qq\|.*\|"
 color red "(alt|bgcolor|height|href|label|longdesc|name|onclick|onfocus|onload|onmouseover|size|span|src|style|target|type|value|width)="


### PR DESCRIPTION
Since the non-greedy operator `?` causes an error, I've implemented non-greedy matching using not-quote zero or more times (`[^"]*`) instead.
