### PR TITLE
Allow short ledger and beancount extensions

### DIFF
--- a/ledger.nanorc
+++ b/ledger.nanorc
@@ -1,4 +1,4 @@
-syntax "ledger" "(^|\.|/)ledger|beancount$"
+syntax "ledger" "(^|\.|/)ledger|ldgr|beancount|bnct$"
 
 color brightmagenta  "^([0-9]{4}(/|-)[0-9]{2}(/|-)[0-9]{2}|[=~]) .*"
 color blue   "^[0-9]{4}(/|-)[0-9]{2}(/|-)[0-9]{2}"


### PR DESCRIPTION
I have seen those variations used by others, so they seem like a logical addition.