### PR TITLE
improved puppet highlighting from https://github.com/llowder/puppet-nano/

### DIFF
--- a/puppet.nanorc
+++ b/puppet.nanorc
@@ -5,9 +5,12 @@ syntax "puppet" "\.pp$"
 #This goes first, so the normal builtins will override in some classes
 ## Paramerers
 color brightwhite "^[[:space:]]([a-z][a-z0-9_]+)"
+color brightgreen "\$[a-z:][a-z0-9_:]+"
 
 ## List of built in types, also catches defines
-color yellow "\<(augeas|computer|cron|exec|file|filebucket|group|host|interface|k5login|macauthorization|mailalias|maillist|mcx|mount|nagios_command|nagios_contact|nagios_contactgroup|nagios_host|nagios_hostdependency|nagios_hostescalation|nagios_hostextinfo|nagios_hostgroup|nagios_service|nagios_servicedependency|nagios_serviceescalation|nagios_serviceextinfo|nagios_servicegroup|nagios_timeperiod|notify|package|resources|router|schedule|scheduled_task|selboolean|selmodule|service|ssh_authorized_key|sshkey|stage|tidy|user|vlan|yumrepo|zfs|zone|zpool|)\>"
+color yellow "\<(augeas|computer|cron|exec|file|filebucket|group|host|interface|k5login|macauthorization|mailalias|maillist|mcx|mount|nagios_command|nagios_contact|nagios_contactgroup|nagios_host|nagios_hostdependency|nagios_hostescalation|nagios_hostextinfo|nagios_hostgroup|nagios_service|nagios_servicedependency|nagios_serviceescalation|nagios_serviceextinfo|nagios_servicegroup|nagios_timeperiod|notify|package|resources|router|schedule|scheduled_task|selboolean|selmodule|service|ssh_authorized_key|sshkey|stage|tidy|user|vlan|yumrepo|zfs|zone|zpool|anchor)\>"
+color yellow "\<(class|define|if|else|undef|inherits)\>"
+color red "(=|-|~|>)"
 
 ## Constants
 color brightblue "(\$|@|@@)?\<[A-Z]+[0-9A-Z_a-z]*"
@@ -31,5 +34,5 @@ color brightcyan "##[^{].*$" "##$"
 ## Some common markers
 color brightcyan "(XXX|TODO|FIXME|\?\?\?)"
 ## Trailing spaces
-color ,red "[[:space:]]+$"
+color red "[[:space:]]+$"
 


### PR DESCRIPTION
I was getting the following error from nano 2.4.2 on OS X:
```
Error in /Users/bryan/.nano-syntax/puppet.nanorc on line 10: Bad regex "[[:<:]](augeas|computer|cron|exec|file|filebucket|group|host|interface|k5login|macauthorization|mailalias|maillist|mcx|mount|nagios_command|nagios_contact|nagios_contactgroup|nagios_host|nagios_hostdependency|nagios_hostescalation|nagios_hostextinfo|nagios_hostgroup|nagios_service|nagios_servicedependency|nagios_serviceescalation|nagios_serviceextinfo|nagios_servicegroup|nagios_timeperiod|notify|package|resources|router|schedule|scheduled_task|selboolean|selmodule|service|ssh_authorized_key|sshkey|stage|tidy|user|vlan|yumrepo|zfs|zone|zpool|)[[:>:]]": empty (sub)expression
```

```
$ nano --version
 GNU nano, version 2.4.2
 (C) 1999..2015 Free Software Foundation, Inc.
 Email: nano@nano-editor.org	Web: http://www.nano-editor.org/
 Compiled options: --disable-libmagic --disable-nls --enable-utf8
```

I found an alternative file at https://github.com/llowder/puppet-nano/ which seems to work fine.

All credits to @llowder!