### PR TITLE
perl6 in nanorc includes

### DIFF
--- a/nanorc
+++ b/nanorc
@@ -43,6 +43,7 @@ include ~/.nano/nginx.nanorc
 include ~/.nano/patch.nanorc
 include ~/.nano/peg.nanorc
 include ~/.nano/perl.nanorc
+include ~/.nano/perl6.nanorc
 include ~/.nano/php.nanorc
 include ~/.nano/pkg-config.nanorc
 include ~/.nano/pkgbuild.nanorc


### PR DESCRIPTION
When I added the CPAN syntax highlighting to `perl6.nanorc` some time ago I forgot to update 
`~/.nano/nanorc`.  As a result `install.sh` wasn't including the line when copying to `~/.nanorc`.