### PR TITLE
Add missing std library keywords for Lua 5.2 and 5.3

### DIFF
--- a/lua.nanorc
+++ b/lua.nanorc
@@ -24,18 +24,20 @@ color brightyellow ":|\*\*|\*|/|%|\+|-|\^|>|>=|<|<=|~=|=|\.\.|\<(not|and|or)\>"
 color brightblue "\<(do|end|while|repeat|until|if|elseif|then|else|for|in|function|local|return)\>"
 
 # Keywords
-color brightyellow "\<(debug|string|math|table|io|coroutine|os)\>\."
-color brightyellow "\<(_G|_VERSION|assert|collectgarbage|dofile|error|getfenv|getmetatable|ipairs|load|loadfile|module|next|pairs|pcall|print|rawequal|rawget|rawset|require|select|setfenv|setmetatable|tonumber|tostring|type|unpack|xpcall)\s*\("
+color brightyellow "\<(debug|string|math|table|io|coroutine|os|utf8|bit32)\>\."
+color brightyellow "\<(_ENV|_G|_VERSION|assert|collectgarbage|dofile|error|getfenv|getmetatable|ipairs|load|loadfile|module|next|pairs|pcall|print|rawequal|rawget|rawlen|rawset|require|select|setfenv|setmetatable|tonumber|tostring|type|unpack|xpcall)\s*\("
 
 # Standard library
 color brightyellow "io\.\<(close|flush|input|lines|open|output|popen|read|tmpfile|type|write)\>"
-color brightyellow "math\.\<(abs|acos|asin|atan2|atan|ceil|cosh|cos|deg|exp|floor|fmod|frexp|huge|ldexp|log10|log|max|min|modf|pi|pow|rad|random|randomseed|sinh|tan)\>"
+color brightyellow "math\.\<(abs|acos|asin|atan2|atan|ceil|cosh|cos|deg|exp|floor|fmod|frexp|huge|ldexp|log10|log|max|maxinteger|min|mininteger|modf|pi|pow|rad|random|randomseed|sinh|sqrt|tan|tointeger|type|ult)\>"
 color brightyellow "os\.\<(clock|date|difftime|execute|exit|getenv|remove|rename|setlocale|time|tmpname)\>"
-color brightyellow "package\.\<(cpath|loaded|loadlib|path|preload|seeall)\>"
-color brightyellow "string\.\<(byte|char|dump|find|format|gmatch|gsub|len|lower|match|rep|reverse|sub|upper)\>"
-color brightyellow "table\.\<(concat|insert|maxn|remove|sort)\>"
-color brightyellow "coroutine\.\<(create|resume|running|status|wrap|yield)\>"
-color brightyellow "debug\.\<(debug|getfenv|gethook|getinfo|getlocal|getmetatable|getregistry|getupvalue|setfenv|sethook|setlocal|setmetatable|setupvalue|traceback)\>"
+color brightyellow "package\.\<(config|cpath|loaded|loadlib|path|preload|seeall|searchers|searchpath)\>"
+color brightyellow "string\.\<(byte|char|dump|find|format|gmatch|gsub|len|lower|match|pack|packsize|rep|reverse|sub|unpack|upper)\>"
+color brightyellow "table\.\<(concat|insert|maxn|move|pack|remove|sort|unpack)\>"
+color brightyellow "utf8\.\<(char|charpattern|codes|codepoint|len|offset)\>"
+color brightyellow "coroutine\.\<(create|isyieldable|resume|running|status|wrap|yield)\>"
+color brightyellow "debug\.\<(debug|getfenv|gethook|getinfo|getlocal|getmetatable|getregistry|getupvalue|getuservalue|setfenv|sethook|setlocal|setmetatable|setupvalue|setuservalue|traceback|upvalueid|upvaluejoin)\>"
+color brightyellow "bit32\.\<(arshift|band|bnot|bor|btest|bxor|extract|replace|lrotate|lshift|rrotate|rshift|)\>"
 
 # File handle methods
 color brightyellow "\:\<(close|flush|lines|read|seek|setvbuf|write)\>"


### PR DESCRIPTION
Here is a new one that I've just noticed and fixed.