### PR TITLE
Highlight trailing whitespaces

### DIFF
--- a/lua.nanorc
+++ b/lua.nanorc
@@ -71,3 +71,6 @@ color green "\-\-.*$"
 
 # Multiline comments
 color green start="\s*\-\-\s*\[\[" end="\]\]"
+
+# Trailing whitespaces
+color ,green "[[:space:]]+$"


### PR DESCRIPTION
Taken from the sh.nanorc file for highlighting trailing whitespaces