### PR TITLE
add trailing whitespace to pkgbuild.nanorc

### DIFF
--- a/pkgbuild.nanorc
+++ b/pkgbuild.nanorc
@@ -21,3 +21,6 @@ color brightred "build\(\)"
 color brightred "package_.*.*$"
 color brightred "\<(configure|make|cmake|scons)\>"
 color red "\<(DESTDIR|PREFIX|prefix|sysconfdir|datadir|libdir|includedir|mandir|infodir)\>"
+
+## Trailing whitespace
+color ,green "[[:space:]]+$"


### PR DESCRIPTION
I missed highlighting of trailing whitespace in pkgbuild.nanorc