### PR TITLE
coffeescript regex escapes fixed

### DIFF
--- a/coffeescript.nanorc
+++ b/coffeescript.nanorc
@@ -1,7 +1,7 @@
 syntax "CoffeeScript" "\.coffee$"
 header "^#!.*/(env +)?coffee"
 
-color red "[!&|=/*+\-<>]|\<(and|or|is|isnt|not)\>"
+color red "[!&|=\/*+\-\<\>]|\<(and|or|is|isnt|not)\>"
 color brightblue "[A-Za-z_][A-Za-z0-9_]*:[[:space:]]*(->|\()" "->"
 color brightblue "[()]"
 color cyan  "\<(for|of|continue|break|isnt|null|unless|this|else|if|return)\>"


### PR DESCRIPTION
Eliminates nano errors. #107

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/scopatz/nanorc/108)
<!-- Reviewable:end -->
