### PR TITLE
use wget instead of curl for automatic installer

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -27,4 +27,8 @@ You can also append the contents of ``~/.nano/nanorc`` into your
     
 Finally, you can run an automatic installer using the following code::
 
+    $ curl https://raw.githubusercontent.com/scopatz/nanorc/master/install.sh | sh
+
+or alternatively::
+
     $ wget https://raw.githubusercontent.com/scopatz/nanorc/master/install.sh -O- | sh

--- a/Readme.rst
+++ b/Readme.rst
@@ -27,4 +27,4 @@ You can also append the contents of ``~/.nano/nanorc`` into your
     
 Finally, you can run an automatic installer using the following code::
 
-    $ curl https://raw.githubusercontent.com/scopatz/nanorc/master/install.sh | sh
+    $ wget https://raw.githubusercontent.com/scopatz/nanorc/master/install.sh -O- | sh


### PR DESCRIPTION
reasons to use wget includes: 
wget is more ubiquitously available than curl. (my particular problem: curl isn't shipped in Debian by default)

wget's ability to recover from a prematurely broken transfer and continue downloading has no counterpart in curl.

reasons for using curl:
... in theory, curl could be faster by enabling --compressed , which would make the github servers gzip-compress the transfer (curl: "Accept-Encoding: deflate, gzip" github: "Content-Encoding: gzip", which as of speaking would save 158 bytes, extra header not accounted for)

but since we're not using --compressed anyway, and that the script is really small (355 bytes), it's a moot point.

i think we should use wget.