### PR TITLE
Fixed typo (and changed color) for trailing whitespace

### DIFF
--- a/puppet.nanorc
+++ b/puppet.nanorc
@@ -34,5 +34,5 @@ color brightcyan "##[^{].*$" "##$"
 ## Some common markers
 color brightcyan "(XXX|TODO|FIXME|\?\?\?)"
 ## Trailing spaces
-color red "[[:space:]]+$"
+color ,green "[[:space:]]+$"
 


### PR DESCRIPTION
Fix typo (and change color) for trailing whitespace in puppet.nanorc