### PR TITLE
Added "revise" temporary files from composure

### DIFF
--- a/sh.nanorc
+++ b/sh.nanorc
@@ -1,6 +1,6 @@
 ## Here is an example for Bourne shell scripts.
 ##
-syntax "SH" "\.sh$" "\.bashrc" "bashrc" "\.bash_aliases" "bash_aliases" "\.bash_functions" "bash_functions" "\.bash_profile" "bash_profile"
+syntax "SH" "\.sh$" "\.bashrc" "bashrc" "\.bash_aliases" "bash_aliases" "\.bash_functions" "bash_functions" "\.bash_profile" "bash_profile" "revise\..+$"
 header "^#!.*/(env +)?(ba)?sh( |$)"
 
 color green "\<(case|do|done|elif|else|esac|exit|fi|for|function|if|in|local|read|return|select|shift|then|time|until|while)\>"


### PR DESCRIPTION
I use [composure](/erichs/composure) frequently for ease of editing/maintaining functions, but it names its temporary files for revising a function "revise.*x*" where *x* is a four-character random string. It's a bash function in a file though, so it really should have bash syntax highlighting.