### PR TITLE
Fixing Markdown quotes that span more than one line.

### DIFF
--- a/markdown.nanorc
+++ b/markdown.nanorc
@@ -4,6 +4,7 @@ syntax "Markdown" "\.(md|mkd|mkdn|markdown)$"
 color cyan ".*[ :]\|[ :].*"
 
 # quotes
+color brightblack  start="^>" end="^$"
 color brightblack  "^>.*"
 
 # Emphasis


### PR DESCRIPTION
To break out of a quote-block in Markdown, one has to have two line-breaks. It's the same as usual paragraphs, so having only one line-break results in it being collapsed as a single space. To represent that behavior here, I'm using start-end, with the previous match being the "start", and a blank line (^$) being the "end".

The current behavior has only the first line highlighted, even though multiple lines should be included in the quote.