### PR TITLE
shellcheck fixes

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ _fetch_sources(){
     mkdir ~/.nano/
   fi
 
-  cd ~/.nano/
+  cd ~/.nano/ || exit
 
   unzip -o "/tmp/nanorc.zip"
   mv nanorc-master/* ./
@@ -22,9 +22,9 @@ _update_nanorc(){
   fi
 
   # add all includes from ~/.nano/nanorc if they're not already there
-  while read inc; do
+  while read -r inc; do
       if ! grep -q "$inc" "${NANORC_FILE}"; then
-          echo "$inc" >> $NANORC_FILE
+          echo "$inc" >> "$NANORC_FILE"
       fi
   done < ~/.nano/nanorc
 }


### PR DESCRIPTION
> [SC2164](https://github.com/koalaman/shellcheck/wiki/SC2164): Use cd ... || exit in case cd fails.  (line 10)

>> [SC2162](https://github.com/koalaman/shellcheck/wiki/SC2162): read without -r will mangle backslashes. (line 25)

>>>  [SC2086](https://github.com/koalaman/shellcheck/wiki/SC2086): Double quote to prevent globbing and word splitting (line 27)
