### PR TITLE
travis-ci shellcheck test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+sudo: required
+dist: trusty
+
+before_install:
+  - echo 'deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse' | sudo tee -a /etc/apt/sources.list
+  - sudo apt-get -qq update
+  - sudo apt-get install -y shellcheck
+
+git:
+  depth: 3
+
+script: ./shellcheck.sh

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ _fetch_sources(){
     mkdir ~/.nano/
   fi
 
-  cd ~/.nano/
+  cd ~/.nano/ || exit
 
   unzip -o "/tmp/nanorc.zip"
   mv nanorc-master/* ./
@@ -22,9 +22,9 @@ _update_nanorc(){
   fi
 
   # add all includes from ~/.nano/nanorc if they're not already there
-  while read inc; do
+  while read -r inc; do
       if ! grep -q "$inc" "${NANORC_FILE}"; then
-          echo "$inc" >> $NANORC_FILE
+          echo "$inc" >> "$NANORC_FILE"
       fi
   done < ~/.nano/nanorc
 }

--- a/shellcheck.sh
+++ b/shellcheck.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -ev
+# Shellcheck the script
+
+shellcheck install.sh


### PR DESCRIPTION
- [ ] [Requires Pull#162](https://github.com/scopatz/nanorc/pull/162) - fixes what shellcheck will find

- [ ] [Requires Travis](https://travis-ci.org/) - run shellcheck test script

- [ ] **Once you’re signed in to Travis CI, and synchronized your GitHub repositories, go to your profile page and go to settings (Gear Icon) in the nanorc repository and enable "Build only if .travis.yml is present."**

- [ ] **Enable the nanorc repository from profile page"**

- [x] create .travis.yml with ubuntu trusty and shellcheck

- [x] make a test script

- [ ] Merge [Pull#163](https://github.com/scopatz/nanorc/pull/163l)

This pull request will introduce a shellcheck test using Travis if someone with write access follows the travis link above to enable on the repo, change setting and merge pull request. The build will pass.