### PR TITLE
[yaml] Color 'normal' back to 'brightwhite'

### DIFF
--- a/yaml.nanorc
+++ b/yaml.nanorc
@@ -14,8 +14,8 @@ color yellow "[:-]\s+[0-9]+\.?[0-9]*(\s*($|#))"
 color yellow "(^| )!!(binary|bool|float|int|map|null|omap|seq|set|str) "
 
 # Separator
-color normal "^\s+-"
-color normal ":(\s|\t|$)"
+color brightwhite "^\s+-"
+color brightwhite ":(\s|\t|$)"
 
 # Comments
 color white "(^|[[:space:]])#.*$"


### PR DESCRIPTION
It seems that older versions of Nano don't support the color 'normal', as @jurajama pointed out. The commit which added the 'normal' color can be found [here](http://git.savannah.gnu.org/cgit/nano.git/commit/?id=570fb6c6062bd62dd3b049550110d7b26af37fa0). 

This fixes issue #168 (@jc-iacono's and @DDifDEVzero's comment) and @jurajama's comment on my earlier commit.

Hope this will work for everyone and the issue can be closed. 