### PR TITLE
Bright red possible errors

### DIFF
--- a/nanorc.nanorc
+++ b/nanorc.nanorc
@@ -2,7 +2,7 @@
 ##
 syntax "Nanorc" "\.?nanorc$"
 ## Possible errors and parameters
-icolor brightwhite "^[[:space:]]*((un)?set|include|syntax|i?color).*$"
+icolor brightred "^[[:space:]]*((un)?set|include|syntax|i?color).*$"
 ## Keywords
 icolor brightgreen "^[[:space:]]*(set|unset)[[:space:]]+(autoindent|backup|backupdir|backwards|boldtext|brackets|casesensitive|const|cut|fill|historylog|matchbrackets|morespace|mouse|multibuffer|noconvert|nofollow|nohelp|nonewlines|nowrap|operatingdir|preserve|punct)\>" "^[[:space:]]*(set|unset)[[:space:]]+(quickblank|quotestr|rebinddelete|rebindkeypad|regexp|smarthome|smooth|speller|suspend|tabsize|tabstospaces|tempfile|undo|view|whitespace|wordbounds)\>"
 icolor green "^[[:space:]]*(set|unset|include|syntax|header)\>"


### PR DESCRIPTION
As a black-text-on-white-terminal user the `brightwhite` setting was rather sub-optimal. Also, red is more of a warning color than white imho.