### PR TITLE
Maintain older nano compatibility

### DIFF
--- a/prolog.nanorc
+++ b/prolog.nanorc
@@ -32,4 +32,4 @@ color white start="/\*" end="\*/"
 color black,yellow "(BUG|DEBUG|FIXME|IDEA|NOTE|REVIEW|TEMP|TODO|WARNING|XXX)"
 
 # Spaces in front of tabs
-color ,red " +  +"
+color ,red " +	+"

--- a/prolog.nanorc
+++ b/prolog.nanorc
@@ -1,10 +1,10 @@
 ## Here is a prolog example.
 
-syntax prolog "\.pl"
+syntax "prolog" "\.pl"
 comment "%"
 
 # Reset everything
-color normal ".*"
+color brightwhite ".*"
 
 # Integers and floats
 color yellow "(^| |=)[0-9]+\.?[0-9]*"
@@ -18,7 +18,7 @@ color yellow "(^|[[:blank:]]|\(|,)_($|[[:blank:]]|,|\))"
 
 # Functions
 color cyan "(^|[[:blank:]])\w+\("
-color normal "\(|\)|\[|\]|,|=|\\="
+color brightwhite "\(|\)|\[|\]|,|=|\\="
 
 # Atoms
 color green start="\"" end="\""
@@ -32,4 +32,4 @@ color white start="/\*" end="\*/"
 color black,yellow "(BUG|DEBUG|FIXME|IDEA|NOTE|REVIEW|TEMP|TODO|WARNING|XXX)"
 
 # Spaces in front of tabs
-color ,red " +	+"
+color ,red " +  +"


### PR DESCRIPTION
Hi, 

Attempt to fix #186

As I understand from previous [commits](https://github.com/scopatz/nanorc/commit/56e9257f56e9c721f56ae26136b984aa88a345c2), legacy compatibility has cared about this repo.
Unfortunately, the new [prolog](https://github.com/scopatz/nanorc/commit/0726842a72c378e060245f9d330326ded0466ab4) syntax does not follow that.

I have errors with nano v2.7.4 and v2.5.3:

```
Error in /usr/share/nano-syntax-highlighting/prolog.nanorc on line 3: A syntax name must be quoted
...
Error in /usr/share/nano-syntax-highlighting/prolog.nanorc on line 7: Color "normal" not understood.
...
```