### PR TITLE
Fixes nano's complaints with prolog.nanorc

### DIFF
--- a/prolog.nanorc
+++ b/prolog.nanorc
@@ -1,10 +1,10 @@
 ## Here is a prolog example.
 
-syntax prolog "\.pl"
+syntax "prolog" "\.pl"
 comment "%"
 
 # Reset everything
-color normal ".*"
+color white ".*"
 
 # Integers and floats
 color yellow "(^| |=)[0-9]+\.?[0-9]*"
@@ -18,7 +18,7 @@ color yellow "(^|[[:blank:]]|\(|,)_($|[[:blank:]]|,|\))"
 
 # Functions
 color cyan "(^|[[:blank:]])\w+\("
-color normal "\(|\)|\[|\]|,|=|\\="
+color white "\(|\)|\[|\]|,|=|\\="
 
 # Atoms
 color green start="\"" end="\""


### PR DESCRIPTION
1. Nano complains that `syntax` requires strings to be quoted.
2. `color normal` fails.  Color can only be white, black, red, blue, green, yellow, magenta, and cyan