### PR TITLE
fix PHP classes with underscore character

### DIFF
--- a/php.nanorc
+++ b/php.nanorc
@@ -6,7 +6,7 @@ color brightblue "([a-zA-Z0-9_-]*)\("
 # Constructs
 color brightblue "(class|extends|goto) ([a-zA-Z0-9_]*)"
 color green "[^a-z0-9_-]{1}(var|class|function|echo|case|break|default|exit|switch|if|else|elseif|endif|foreach|endforeach|@|while|public|private|protected|return|true|false|null|TRUE|FALSE|NULL|const|static|extends|as|array|require|include|require_once|include_once|define|do|continue|declare|goto|print|in|namespace|use)[^a-z0-9_-]{1}"
-color brightblue "[a-zA-Z0-9]+:"
+color brightblue "[a-zA-Z0-9_]+:"
 # Variables
 color white "\$[a-zA-Z_0-9$]*|[=!<>]"
 color white "\->[a-zA-Z_0-9$]*|[=!<>]"


### PR DESCRIPTION
fix an issue for highlighting a class in code like this
```php
Some_Utils::doStuff();
```
before fix only last part of classname was highlighted