### PR TITLE
Better haskell highlighting

### DIFF
--- a/haskell.nanorc
+++ b/haskell.nanorc
@@ -1,34 +1,48 @@
 syntax "Haskell" "\.hs$"
+comment "-- "
+
+## Numbers (hex, oct, dec)
+color magenta "((0[xX][0-9a-fA-F]+)|(0[oO][0-7]+)|([0-9]+(\.[0-9]+)?(e[0-9]+(\.[0-9]+)?)?))"
+
+## Operators
+color cyan "[^(a-z)^(A-Z)^(0-9)^ ]*"
+
+## Chars
+color green "'([^']|\\')'"
+
+## Types, constructors, modules
+color yellow "([ ]|^)+([A-Z][a-zA-Z0-9']*)"
+
+## Names
+color normal "([ ]|^)+[a-z][a-zA-Z0-9'_]*"
+
+## Infix backticked names
+color cyan "`[a-z][a-zA-Z0-9'_]*`"
+
+## Strings
+color green "\"([^\"\\]|\\.)*\""
+
+## Commas, brac(k)e(t)s
+color normal "(,|\[|\]|\{|\}|\(|\))"
+
+## Special sugar
+color magenta "\([ ]*\)"
+color magenta "\[[ ]*\]"
 
 ## Keywords
 color red "[ ](as|case|of|class|data|default|deriving|do|forall|foreign|hiding|if|then|else|import|infix|infixl|infixr|instance|let|in|mdo|module|newtype|qualified|type|where)[ ]"
 color red "(^data|^foreign|^import|^infix|^infixl|^infixr|^instance|^module|^newtype|^type)[ ]"
 color red "[ ](as$|case$|of$|class$|data$|default$|deriving$|do$|forall$|foreign$|hiding$|if$|then$|else$|import$|infix$|infixl$|infixr$|instance$|let$|in$|mdo$|module$|newtype$|qualified$|type$|where$)"
 
-## Various symbols
-color cyan "(\||@|!|:|_|~|=|\\|;|\(\)|,|\[|\]|\{|\})"
-
-## Operators
-color magenta "(==|/=|&&|\|\||<|>|<=|>=)"
-
-## Various symbols
-color cyan "(->|<-)"
-color magenta "\.|\$"
-
-## Data constructors
-color magenta "(True|False|Nothing|Just|Left|Right|LT|EQ|GT)"
-
-## Data classes
-color magenta "[ ](Read|Show|Enum|Eq|Ord|Data|Bounded|Typeable|Num|Real|Fractional|Integral|RealFrac|Floating|RealFloat|Monad|MonadPlus|Functor)"
-
-## Strings
-color yellow ""[^\"]*""
+## undefined
+color brightred "undefined"
 
 ## Comments
-color green "--.*"
-color green start="\{-" end="-\}"
+color brightblue "-- .*"
+color brightblue start="\{-" end="-\}"
 
-color brightred "undefined"
+## Extensions
+color brightred start="\{-#" end="#-\}"
 
 ## Trailing spaces
 color ,green "[[:space:]]+$"


### PR DESCRIPTION
More generic highlighting for user defined types, strings with escape characters, extensions, operators, infix operators, and hex/oct/dec numbers with scientific notation.