### PR TITLE
Add missing keywords to Dockerfile

### DIFF
--- a/Dockerfile.nanorc
+++ b/Dockerfile.nanorc
@@ -2,7 +2,7 @@
 syntax "Dockerfile" "Dockerfile[^/]*$" "\.dockerfile$"
 
 ## Keywords
-icolor red "^(FROM|MAINTAINER|RUN|CMD|LABEL|EXPOSE|ENV|ADD|COPY|ENTRYPOINT|VOLUME|USER|WORKDIR|ONBUILD)[[:space:]]"
+icolor red "^(FROM|RUN|CMD|LABEL|MAINTAINER|EXPOSE|ENV|ADD|COPY|ENTRYPOINT|VOLUME|USER|WORKDIR|ARG|ONBUILD|STOPSIGNAL|HEALTHCHECK|SHELL)[[:space:]]"
 
 ## Brackets & parenthesis
 color brightgreen "(\(|\)|\[|\])"


### PR DESCRIPTION
I noticed that we miss some keywords for Dockerfiles and I added them.

Also the MAINTAINER tag was at the wrong position according to https://docs.docker.com/engine/reference/builder/