### PR TITLE
Fixes ruby syntax highlighting regex

### DIFF
--- a/ruby.nanorc
+++ b/ruby.nanorc
@@ -6,7 +6,7 @@ header "^#!.*/(env +)?ruby( |$)"
 ## Asciibetical list of reserved words
 color yellow "\<(BEGIN|END|alias|and|begin|break|case|class|def|defined\?|do|else|elsif|end|ensure|false|for|if|in|module|next|nil|not|or|redo|rescue|retry|return|self|super|then|true|undef|unless|until|when|while|yield)\>"
 ## Constants
-color brightblue "(\$|@|@@)?\<[A-Z]+[0-9A-Z_a-z]*"
+color brightblue "(\$|@|@@)\<[A-Z]+[0-9A-Z_a-z]*"
 ## Ruby "symbols"
 icolor magenta "([ 	]|^):[0-9A-Z_]+\>"
 ## Some unique things we want to stand out


### PR DESCRIPTION
The current regex for ruby constants has an error and matches way more than it
should.  It overwrites the reserved words and most variable names with bright
blue - making it hard to read.  Change the regex to match exactly 1 of $|@|@@
instead of matching 1 or 0.