### PR TITLE
fix highlighting for v2.9.*

### DIFF
--- a/Readme.rst
+++ b/Readme.rst
@@ -54,11 +54,11 @@ where ``$install_path`` is ``/usr/share/nano-syntax-highlighting`` or ``~/.nano/
 ~~~~~~~~~~~~~~~~~~~~~~
 Finally, you can run an automatic installer using the following code::
 
-    $ curl https://raw.githubusercontent.com/scopatz/nanorc/master/install.sh | sh
+    $ curl https://raw.githubusercontent.com/scopatz/nanorc/v2.9/install.sh | sh
 
 or alternatively::
 
-    $ wget https://raw.githubusercontent.com/scopatz/nanorc/master/install.sh -O- | sh
+    $ wget https://raw.githubusercontent.com/scopatz/nanorc/v2.9/install.sh -O- | sh
 
 *Note -
     some syntax definitions which exist in Nano upstream may be preferable to the ones provided by this package.

--- a/Readme.rst
+++ b/Readme.rst
@@ -13,15 +13,15 @@ These should be placed inside of the ``~/.nano/`` directory.
 Or for system-wide installation ``/usr/share/nano-syntax-highlighting/``.
 In other words::
 
-    git clone git@github.com:scopatz/nanorc.git ~/.nano
+    git clone --single-branch --branch=v2.9 git@github.com:scopatz/nanorc.git ~/.nano
 
 *Note - if you have any issues (ssh was not properly configured), alternatively use::
 
-    git clone https://github.com/scopatz/nanorc.git ~/.nano
+    git clone --single-branch --branch=v2.9 https://github.com/scopatz/nanorc.git ~/.nano
     
 *System wide will look like so*::
 
-    sudo git clone https://github.com/scopatz/nanorc.git /usr/share/nano-syntax-highlighting/
+    sudo git clone --single-branch --branch=v2.9 https://github.com/scopatz/nanorc.git /usr/share/nano-syntax-highlighting/
 
 **NOTE**: \< and \> are regular character escapes on macOS. The bug's fixed in Nano, but this might be a problem
 if you are using an older version. If this is the case, replace them respectively with [[:<:]] and [[:>:]].

--- a/etc-hosts.nanorc
+++ b/etc-hosts.nanorc
@@ -8,7 +8,7 @@ color yellow "^[0-9\.]+\s"
 icolor green "^[0-9a-f:]+\s"
 
 # interpunction
-color normal "[.:]"
+color white "[.:]"
 
 # comments
 color brightblack "^#.*"

--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ if [ ! "$(command -v unzip)" ]; then
 fi
 
 _fetch_sources(){
-  wget -O /tmp/nanorc.zip https://github.com/scopatz/nanorc/archive/master.zip
+  wget -O /tmp/nanorc.zip https://github.com/scopatz/nanorc/archive/v2.9.zip
   if [ ! -d ~/.nano/ ]
   then
     mkdir ~/.nano/
@@ -15,8 +15,8 @@ _fetch_sources(){
 
   cd ~/.nano/ || exit
   unzip -o "/tmp/nanorc.zip"
-  mv nanorc-master/* ./
-  rm -rf nanorc-master
+  mv nanorc-v2.9/* ./
+  rm -rf nanorc-v2.9
   rm /tmp/nanorc.zip
 }
 


### PR DESCRIPTION
Get rid of message `Error in /usr/share/nano-syntax-highlighting/etc-hosts.nanorc on line 11: Color "normal" not understood.` after nano exits.