### PR TITLE
Add "least", "fast" and "max" C fixed-width types

### DIFF
--- a/c.nanorc
+++ b/c.nanorc
@@ -3,7 +3,7 @@
 syntax "C" "\.(c(c|pp|xx)?|C)$" "\.(h(h|pp|xx)?|H)$" "\.ii?$" "\.(def)$"
 color brightred "\<[A-Z_][0-9A-Z_]+\>" 
 color green "\<(float|double|bool|char|wchar_t|int|short|long|sizeof|enum|void|static|const|struct|union|typedef|extern|(un)?signed|inline)\>"
-color green "\<((s?size)|(char(16|32))|((u_?)?int(8|16|32|64|ptr)))_t\>"
+color green "\<((s?size)|(char(16|32))|((u_?)?int(_fast|_least)?(8|16|32|64))|u?int(max|ptr))_t\>"
 color green "\<(class|namespace|template|public|protected|private|typename|this|friend|virtual|using|mutable|volatile|register|explicit)\>"
 color green "\<(for|if|while|do|else|case|default|switch)\>"
 color green "\<(try|throw|catch|operator|new|delete)\>"


### PR DESCRIPTION
# Changes

This PR adds support for the remaining C99/C++11 fixed-width types:
```c
int_fast8_t
int_fast16_t
int_fast32_t
int_fast64_t

int_least8_t
int_least16_t
int_least32_t
int_least64_t

uint_fast8_t
uint_fast16_t
uint_fast32_t
uint_fast64_t

uint_least8_t
uint_least16_t
uint_least32_t
uint_least64_t

intmax_t
uintmax_t
```

I have tested the changes with `nano` as well as other regex testing tools.

I didn't add the respective versions for `u_int...` because I couldn't find reliable sources on this topic.