### PR TITLE
Update prolog.nanorc

### DIFF
--- a/prolog.nanorc
+++ b/prolog.nanorc
@@ -4,7 +4,7 @@ syntax prolog "\.pl"
 comment "%"
 
 # Reset everything
-color normal ".*"
+color white ".*"
 
 # Integers and floats
 color yellow "(^| |=)[0-9]+\.?[0-9]*"
@@ -18,7 +18,7 @@ color yellow "(^|[[:blank:]]|\(|,)_($|[[:blank:]]|,|\))"
 
 # Functions
 color cyan "(^|[[:blank:]])\w+\("
-color normal "\(|\)|\[|\]|,|=|\\="
+color white "\(|\)|\[|\]|,|=|\\="
 
 # Atoms
 color green start="\"" end="\""


### PR DESCRIPTION
Error in prolog.nanorc on line 7: Color "normal" not understood.
Error in prolog.nanorc on line 21: Color "normal" not understood.
These were changed to white.