### PR TITLE
Fix nano warnings

### DIFF
--- a/prolog.nanorc
+++ b/prolog.nanorc
@@ -1,10 +1,10 @@
 ## Here is a prolog example.
 
-syntax prolog "\.pl"
+syntax "prolog" "\.pl"
 comment "%"
 
 # Reset everything
-color normal ".*"
+color white ".*"
 
 # Integers and floats
 color yellow "(^| |=)[0-9]+\.?[0-9]*"
@@ -18,7 +18,7 @@ color yellow "(^|[[:blank:]]|\(|,)_($|[[:blank:]]|,|\))"
 
 # Functions
 color cyan "(^|[[:blank:]])\w+\("
-color normal "\(|\)|\[|\]|,|=|\\="
+color white "\(|\)|\[|\]|,|=|\\="
 
 # Atoms
 color green start="\"" end="\""


### PR DESCRIPTION
Nano warns of color needing a syntax definition preceding it. This is solved by putting "prolog" in quotes at the top of the file. Nano also complains about the color normal, so I changed it to "white"