### PR TITLE
remove comment syntax for compability with v2.3

### DIFF
--- a/html.nanorc
+++ b/html.nanorc
@@ -2,7 +2,6 @@
 
 syntax "HTML" "\.html?(.j2)?$"
 magic "HTML document"
-comment "<!--|-->"
 
 ## Emphasis tags
 color brightwhite start="<([biu]|em|strong)[^>]*>" end="</([biu]|em|strong)>"


### PR DESCRIPTION
v2.3 is what is installed with the latest Centos7 distro. The comment syntax is not recognized in that version so it can be removed. Comments are already specified later in the file as well:

```
## Comments
color green start="<!--" end="-->"
```

Fixes #238