### PR TITLE
java: Enforce atleast one leading space for comments

### DIFF
--- a/java.nanorc
+++ b/java.nanorc
@@ -7,7 +7,7 @@ color cyan "\<(abstract|class|extends|final|implements|import|instanceof|interfa
 color red ""[^"]*""
 color yellow "\<(true|false|null)\>"
 icolor yellow "\b(([1-9][0-9]+)|0+)\.[0-9]+\b" "\b[1-9][0-9]*\b" "\b0[0-7]*\b" "\b0x[1-9a-f][0-9a-f]*\b"
-color blue "//.*"
+color blue " //.*"
 color blue start="/\*" end="\*/"
 color brightblue start="/\*\*" end="\*/"
 color ,green "[[:space:]]+$"


### PR DESCRIPTION
This might not be the best way to approach the problem

Fixes the case where URLs in Java strings get formatted as comments

Demo: https://imgur.com/a/npOXd62