### PR TITLE
Enforce leading space for comments in all languages

### DIFF
--- a/arduino.nanorc
+++ b/arduino.nanorc
@@ -109,7 +109,7 @@ color brightyellow "<[^=    ]*>" ""(\\.|[^"])*""
 color brightyellow start=""(\\.|[^"])*\\[[:space:]]*$" end="^(\\.|[^"])*""
 
 ## Comments
-color brightblue " //.*"
+color brightblue "^\s*//.*"
 color brightblue start="/\*" end="\*/"
 
 ## Trailing whitespace

--- a/arduino.nanorc
+++ b/arduino.nanorc
@@ -109,7 +109,7 @@ color brightyellow "<[^=    ]*>" ""(\\.|[^"])*""
 color brightyellow start=""(\\.|[^"])*\\[[:space:]]*$" end="^(\\.|[^"])*""
 
 ## Comments
-color brightblue "//.*"
+color brightblue " //.*"
 color brightblue start="/\*" end="\*/"
 
 ## Trailing whitespace

--- a/asm.nanorc
+++ b/asm.nanorc
@@ -11,7 +11,7 @@ color brightcyan "^[[:space:]]*#[[:space:]]*(define|undef|include|ifn?def|endif|
 color brightyellow "<[^= 	]*>" ""(\\.|[^"])*""
 color brightyellow start=""(\\.|[^"])*\\[[:space:]]*$" end="^(\\.|[^"])*""
 ## Highlight comments
-color brightblue " //.*"
+color brightblue "^\s*//.*"
 color brightblue start="/\*" end="\*/"
 ## Highlight trailing whitespace
 color ,green "[[:space:]]+$"

--- a/asm.nanorc
+++ b/asm.nanorc
@@ -11,7 +11,7 @@ color brightcyan "^[[:space:]]*#[[:space:]]*(define|undef|include|ifn?def|endif|
 color brightyellow "<[^= 	]*>" ""(\\.|[^"])*""
 color brightyellow start=""(\\.|[^"])*\\[[:space:]]*$" end="^(\\.|[^"])*""
 ## Highlight comments
-color brightblue "//.*"
+color brightblue " //.*"
 color brightblue start="/\*" end="\*/"
 ## Highlight trailing whitespace
 color ,green "[[:space:]]+$"

--- a/c.nanorc
+++ b/c.nanorc
@@ -35,7 +35,7 @@ color cyan "<[^= 	]*>" ""(\\.|[^"])*""
 #color cyan start=""(\\.|[^"])*\\[[:space:]]*$" end="^(\\.|[^"])*""
 
 ## Comment highlighting
-color brightblue "//.*"
+color brightblue " //.*"
 color brightblue start="/\*" end="\*/"
 
 ## Trailing whitespace

--- a/c.nanorc
+++ b/c.nanorc
@@ -35,7 +35,7 @@ color cyan "<[^= 	]*>" ""(\\.|[^"])*""
 #color cyan start=""(\\.|[^"])*\\[[:space:]]*$" end="^(\\.|[^"])*""
 
 ## Comment highlighting
-color brightblue " //.*"
+color brightblue "^\s*//.*"
 color brightblue start="/\*" end="\*/"
 
 ## Trailing whitespace

--- a/java.nanorc
+++ b/java.nanorc
@@ -7,7 +7,7 @@ color cyan "\<(abstract|class|extends|final|implements|import|instanceof|interfa
 color red ""[^"]*""
 color yellow "\<(true|false|null)\>"
 icolor yellow "\b(([1-9][0-9]+)|0+)\.[0-9]+\b" "\b[1-9][0-9]*\b" "\b0[0-7]*\b" "\b0x[1-9a-f][0-9a-f]*\b"
-color blue " //.*"
+color blue "^\s*//.*"
 color blue start="/\*" end="\*/"
 color brightblue start="/\*\*" end="\*/"
 color ,green "[[:space:]]+$"

--- a/js.nanorc
+++ b/js.nanorc
@@ -49,4 +49,4 @@ color red "\\[0-7][0-7]?[0-7]?|\\x[0-9a-fA-F]+|\\[bfnrt'"\?\\]"
 
 ## Comments
 color brightblue start="/\*" end="\*/"
-color brightblue " //.*$"
+color brightblue "^\s*//.*$"

--- a/js.nanorc
+++ b/js.nanorc
@@ -49,4 +49,4 @@ color red "\\[0-7][0-7]?[0-7]?|\\x[0-9a-fA-F]+|\\[bfnrt'"\?\\]"
 
 ## Comments
 color brightblue start="/\*" end="\*/"
-color brightblue "//.*$"
+color brightblue " //.*$"

--- a/kotlin.nanorc
+++ b/kotlin.nanorc
@@ -19,7 +19,7 @@ color brightred "\<(inner|outer)\>"
 color brightblue "<[^= 	]*>" ""(\\.|[^"])*""
 
 ## Comment highlighting
-color red " //.*"
+color red "^\s*//.*"
 color red start="/\*" end="\*/"
 
 ## Trailing whitespace

--- a/kotlin.nanorc
+++ b/kotlin.nanorc
@@ -19,7 +19,7 @@ color brightred "\<(inner|outer)\>"
 color brightblue "<[^= 	]*>" ""(\\.|[^"])*""
 
 ## Comment highlighting
-color red "//.*"
+color red " //.*"
 color red start="/\*" end="\*/"
 
 ## Trailing whitespace

--- a/pov.nanorc
+++ b/pov.nanorc
@@ -11,5 +11,5 @@ color brightred "\<(fog|object|camera)\>"
 color green "(\{|\}|\(|\)|\;|\]|\[|`|\\|\$|<|>|!|=|&|\|)"
 color brightmagenta "\<(union|group|subgroup)\>"
 ## Comment highlighting
-color brightblue " //.*"
+color brightblue "^\s*//.*"
 color brightblue start="/\*" end="\*/"

--- a/pov.nanorc
+++ b/pov.nanorc
@@ -11,5 +11,5 @@ color brightred "\<(fog|object|camera)\>"
 color green "(\{|\}|\(|\)|\;|\]|\[|`|\\|\$|<|>|!|=|&|\|)"
 color brightmagenta "\<(union|group|subgroup)\>"
 ## Comment highlighting
-color brightblue "//.*"
+color brightblue " //.*"
 color brightblue start="/\*" end="\*/"

--- a/rust.nanorc
+++ b/rust.nanorc
@@ -26,7 +26,7 @@ color green start="\".*\\$" end=".*\""
 color green start="r#+\"" end="\"#+"
 
 # Comments
-color blue " //.*"
+color blue "^\s*//.*"
 color blue start="/\*" end="\*/"
 
 # Attributes

--- a/rust.nanorc
+++ b/rust.nanorc
@@ -26,7 +26,7 @@ color green start="\".*\\$" end=".*\""
 color green start="r#+\"" end="\"#+"
 
 # Comments
-color blue "//.*"
+color blue " //.*"
 color blue start="/\*" end="\*/"
 
 # Attributes

--- a/scala.nanorc
+++ b/scala.nanorc
@@ -6,7 +6,7 @@ color red "\<(match|val|var|break|case|catch|continue|default|do|else|finally|fo
 color cyan "\<(def|object|case|trait|lazy|implicit|abstract|class|extends|final|implements|import|instanceof|interface|native|package|private|protected|public|static|strictfp|super|synchronized|throws|volatile|sealed)\>"
 color red ""[^"]*""
 color yellow "\<(true|false|null)\>"
-color blue "//.*"
+color blue " //.*"
 color blue start="/\*" end="\*/"
 color brightblue start="/\*\*" end="\*/"
 color ,green "[[:space:]]+$"

--- a/scala.nanorc
+++ b/scala.nanorc
@@ -6,7 +6,7 @@ color red "\<(match|val|var|break|case|catch|continue|default|do|else|finally|fo
 color cyan "\<(def|object|case|trait|lazy|implicit|abstract|class|extends|final|implements|import|instanceof|interface|native|package|private|protected|public|static|strictfp|super|synchronized|throws|volatile|sealed)\>"
 color red ""[^"]*""
 color yellow "\<(true|false|null)\>"
-color blue " //.*"
+color blue "^\s*//.*"
 color blue start="/\*" end="\*/"
 color brightblue start="/\*\*" end="\*/"
 color ,green "[[:space:]]+$"

--- a/swift.nanorc
+++ b/swift.nanorc
@@ -55,8 +55,8 @@ color red ""[^"]*""
 color white start="\\\(" end="\)"
 
 # Comments
-color green "//.*"
-color brightgreen "///.*"
+color green " //.*"
+color brightgreen " ///.*"
 color green start="/\*\*" end="\*/"
 color green "[/**]"
 

--- a/swift.nanorc
+++ b/swift.nanorc
@@ -55,8 +55,8 @@ color red ""[^"]*""
 color white start="\\\(" end="\)"
 
 # Comments
-color green " //.*"
-color brightgreen " ///.*"
+color green "^\s*//.*"
+color brightgreen "^\s*///.*"
 color green start="/\*\*" end="\*/"
 color green "[/**]"
 

--- a/ts.nanorc
+++ b/ts.nanorc
@@ -36,7 +36,7 @@ color red "\\[0-7][0-7]?[0-7]?|\\x[0-9a-fA-F]+|\\[bfnrt'"\?\\]"
 
 ## Comments
 color magenta start="/\*" end="\*/"
-color magenta "//.*$"
+color magenta " //.*$"
 
 ## Trailing whitespace
 color ,green "[[:space:]]+$"

--- a/ts.nanorc
+++ b/ts.nanorc
@@ -36,7 +36,7 @@ color red "\\[0-7][0-7]?[0-7]?|\\x[0-9a-fA-F]+|\\[bfnrt'"\?\\]"
 
 ## Comments
 color magenta start="/\*" end="\*/"
-color magenta " //.*$"
+color magenta "^\s*//.*$"
 
 ## Trailing whitespace
 color ,green "[[:space:]]+$"

--- a/verilog.nanorc
+++ b/verilog.nanorc
@@ -74,7 +74,7 @@ color brightyellow ""([^"]|\\")*"" "<[^[:blank:]=]*>"
 ###color brightyellow start=""(\\.|[^"])*\\[[:space:]]*$" end="^(\\.|[^"])*""
 
 # Comments.
-color brightblue " //.*"
+color brightblue "^\s*//.*"
 color brightblue start="/\*" end="\*/"
 
 # Reminders.

--- a/verilog.nanorc
+++ b/verilog.nanorc
@@ -74,7 +74,7 @@ color brightyellow ""([^"]|\\")*"" "<[^[:blank:]=]*>"
 ###color brightyellow start=""(\\.|[^"])*\\[[:space:]]*$" end="^(\\.|[^"])*""
 
 # Comments.
-color brightblue "//.*"
+color brightblue " //.*"
 color brightblue start="/\*" end="\*/"
 
 # Reminders.


### PR DESCRIPTION
Same reasoning as https://github.com/scopatz/nanorc/pull/262

More and more languages kept encountering this problem so this blanket update became necessary.