### PR TITLE
Added support for documentation comments to java.nanorc and c.nanorc

### DIFF
--- a/c.nanorc
+++ b/c.nanorc
@@ -40,5 +40,10 @@ color cyan "<[^= 	]*>" ""(\\.|[^"])*""
 color brightblue "^\s*//.*"
 color brightblue start="/\*" end="\*/"
 
+# Highlighting for documentation comments
+color magenta "@param [a-zA-Z_][a-z0-9A-Z_]+"
+color magenta "@return"
+color magenta "@author.*"
+
 ## Trailing whitespace
 color ,green "[[:space:]]+$"

--- a/java.nanorc
+++ b/java.nanorc
@@ -13,4 +13,10 @@ icolor yellow "\b(([1-9][0-9]+)|0+)\.[0-9]+\b" "\b[1-9][0-9]*\b" "\b0[0-7]*\b" "
 color blue "^\s*//.*"
 color blue start="/\*" end="\*/"
 color brightblue start="/\*\*" end="\*/"
+
+# Highlighting for javadoc stuff
+color magenta "@param [a-zA-Z_][a-z0-9A-Z_]+"
+color magenta "@return"
+color magenta "@author.*"
+
 color ,green "[[:space:]]+$"


### PR DESCRIPTION
I added highlighting for `@param`, `@return`, and `@author`, which are tags used in Javadoc comments to give brief documentation of specific methods. I only added it to the highlighting files for C/C++ and Java, but it might be a good idea to add it to other languages' highlighting files as well.