### PR TITLE
Update to install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -40,6 +40,7 @@ case "$1" in
  -h|--help)
    echo "Install script for nanorc syntax highlights"
    echo "Call with -l or --lite to update .nanorc with secondary precedence to existing .nanorc includes"
+   exit 0
  ;;
 esac
 


### PR DESCRIPTION
When you would run `install.sh -h` or with `--help` flag, it would print those two `echo` lines, but it'd continue on its merry way, installing everything still! A `help` flag is not supposed to do that! So I added an `exit 0` to the help flag.