### PR TITLE
(Haskell) Made "=>" cyan.

### DIFF
--- a/haskell.nanorc
+++ b/haskell.nanorc
@@ -12,7 +12,7 @@ color cyan "(\||@|!|:|_|~|=|\\|;|\(\)|,|\[|\]|\{|\})"
 color magenta "(==|/=|&&|\|\||<|>|<=|>=)"
 
 ## Various symbols
-color cyan "(->|<-)"
+color cyan "(->|<-|=>)"
 color magenta "\.|\$"
 
 ## Data constructors


### PR DESCRIPTION
Added "=>" (typeclass constraint) because the "equals" appeared cyan and the "more than" appeared magenta. This should be one colour (cyan) as it is one symbol.