### PR TITLE
(Haskell) Made "=>" cyan.

### DIFF
--- a/haskell.nanorc
+++ b/haskell.nanorc
@@ -12,7 +12,7 @@ color cyan "(\||@|!|:|_|~|=|\\|;|\(\)|,|\[|\]|\{|\})"
 color magenta "(==|/=|&&|\|\||<|>|<=|>=)"
 
 ## Various symbols
-color cyan "(->|<-)"
+color cyan "(->|<-|=>)"
 color magenta "\.|\$"
 
 ## Data constructors


### PR DESCRIPTION
See #289 for details.