### PR TITLE
feat(js): format template strings

### DIFF
--- a/js.nanorc
+++ b/js.nanorc
@@ -42,6 +42,8 @@ color red "\<(true|false)\>"
 ## String
 color brightyellow "L?\"(\\"|[^"])*\""
 color brightyellow "L?'(\'|[^'])*'"
+color brightcyan "L?`(\`|[^`])*`"
+color brightwhite,blue start="\$\{" end="\}"
 
 ## Trailing spaces
 color ,green "[[:space:]]+$"


### PR DESCRIPTION
Brings the template string configuration in from `.ts`.