### PR TITLE
fix(php): only highlight the spaces that are trailing

### DIFF
--- a/php.nanorc
+++ b/php.nanorc
@@ -37,6 +37,6 @@ color red "(<\?(php)?|\?>)"
 # General HTML
 color red start="\?>" end="<\?(php|=)?"
 # trailing whitespace
-color ,green "[^[:space:]]{1}[[:space:]]+$"
+color ,green "[[:space:]]+$"
 # multi-line comments
 color brightyellow start="/\*" end="\*/"


### PR DESCRIPTION
I looked over all uses of "color ,green" and they're literally all the same regex *except* for php for some reason.

Currently PHP will have both the trailing space and the last char highlighted, which I don't see an advantage to but it's possible I've missed something 🤷‍♀️

If there isn't an advantage, I think its nice to be consistent.