### PR TITLE
Update groff.nanorc

### DIFF
--- a/groff.nanorc
+++ b/groff.nanorc
@@ -14,6 +14,7 @@ color cyan "(\\|\\\\)n(.|\(..)"
 color cyan start="(\\|\\\\)n\[" end="]"
 ## Requests
 color brightgreen "^\.[[:space:]]*[^[[:space:]]]*[^[[:space:]]]*"
+color brightgreen "^\.[[:space:]]*[^[[:space:]]]*"
 ## Comments
 color yellow "^\.\\".*$"
 ## Strings


### PR DESCRIPTION
added original line to allow color of some macros that only have one letter after .