### PR TITLE
* PHP: Improve operator coloring, support Nowdocs, Heredocs

### DIFF
--- a/php.nanorc
+++ b/php.nanorc
@@ -39,9 +39,6 @@ color yellow "( and | or | xor |!|&&|\|\|)"
 # And/Or/SRO/etc
 color green "(\;\;|\|\||::|=>)"
 color cyan "->"
-# Online Comments
-color brightyellow "^(#.*|//.*)$"
-color brightyellow "[	| ](#.*|//.*)$"
 # Double quoted STRINGS!
 color red "(\"[^\"]*\")"
 # Heredoc (typically ends with a semicolon).
@@ -50,6 +47,9 @@ color red start="<<<['\"]?[A-Z][A-Z0-9_]*['\"]?" end="^[A-Z][A-Z0-9_]*;"
 color white "\{\$[^}]*\}"
 # Single quoted string
 color red "('[^']*')"
+# Online Comments
+color brightyellow "^(#.*|//.*)$"
+color brightyellow "[	| ](#.*|//.*)$"
 # PHP Tags
 color red "(<\?(php)?|\?>)"
 # General HTML

--- a/php.nanorc
+++ b/php.nanorc
@@ -3,35 +3,53 @@ syntax "PHP" "\.php[2345s~]?$|\.module$"
 magic "PHP script"
 comment "//"
 color white start="<\?(php|=)?" end="\?>"
-# Functions
-color brightblue "([a-zA-Z0-9_-]*)\("
 # Constructs
 color brightblue "(class|extends|goto) ([a-zA-Z0-9_]*)"
-color green "[^a-z0-9_-]{1}(var|class|function|echo|case|break|default|exit|switch|if|else|elseif|endif|foreach|endforeach|@|while|public|private|protected|return|true|false|null|TRUE|FALSE|NULL|const|static|extends|as|array|require|include|require_once|include_once|define|do|continue|declare|goto|print|in|namespace|use)[^a-z0-9_-]{1}"
+color brightblue "[^a-z0-9_-]{1}(var|class|function|echo|case|break|default|exit|switch|if|else|elseif|endif|foreach|endforeach|@|while|public|private|protected|return|true|false|null|TRUE|FALSE|NULL|const|static|extends|as|array|require|include|require_once|include_once|define|do|continue|declare|goto|print|in|namespace|use)[^a-z0-9_-]{1}"
 color brightblue "[a-zA-Z0-9_]+:"
 # Variables
-color white "\$[a-zA-Z_0-9$]*|[=!<>]"
-color white "\->[a-zA-Z_0-9$]*|[=!<>]"
+color green "\$[a-zA-Z_0-9$]*|[=!<>]"
+color green "\->[a-zA-Z_0-9$]*|[=!<>]"
+# Functions
+color brightblue "([a-zA-Z0-9_-]*)\("
+# Special values
+color brightmagenta "[^a-z0-9_-]{1}(true|false|null|TRUE|FALSE|NULL)$"
+color brightmagenta "[^a-z0-9_-]{1}(true|false|null|TRUE|FALSE|NULL)[^a-z0-9_-]{1}"
 # Special Characters
 color yellow "[.,{}();]"
-color yellow "\["
-color yellow "\]"
-color yellow "[=][^>]"
+color cyan "\["
+color cyan "\]"
 # Numbers
 color magenta "[+-]*([0-9]\.)*[0-9]+([eE][+-]?([0-9]\.)*[0-9])*"
 color magenta "0x[0-9a-zA-Z]*"
 # Special Variables
 color brightblue "(\$this|parent::|self::|\$this->)"
+color magenta ";"
+# Comparison operators
+color yellow "(<|>)"
+# Assignment operator
+color brightblue "="
 # Bitwise Operations
-color magenta "(\;|\||\^){1}"
+color magenta "(&|\||\^)"
+color magenta "(<<|>>)"
+# Comparison operators
+color yellow "(==|===|!=|<>|!==|<=|>=|<=>)"
+# Logical Operators
+color yellow "( and | or | xor |!|&&|\|\|)"
 # And/Or/SRO/etc
-color green "(\;\;|\|\||::|=>|->)"
+color green "(\;\;|\|\||::|=>)"
+color cyan "->"
 # Online Comments
-color brightyellow "(#.*|//.*)$"
-# STRINGS!
-color red "('[^']*')|(\"[^\"]*\")"
+color brightyellow "^(#.*|//.*)$"
+color brightyellow "[	| ](#.*|//.*)$"
+# Double quoted STRINGS!
+color red "(\"[^\"]*\")"
+# Heredoc (typically ends with a semicolon).
+color red start="<<<['\"]?[A-Z][A-Z0-9_]*['\"]?" end="^[A-Z][A-Z0-9_]*;"
 # Inline Variables
 color white "\{\$[^}]*\}"
+# Single quoted string
+color red "('[^']*')"
 # PHP Tags
 color red "(<\?(php)?|\?>)"
 # General HTML
@@ -40,3 +58,5 @@ color red start="\?>" end="<\?(php|=)?"
 color ,green "[[:space:]]+$"
 # multi-line comments
 color brightyellow start="/\*" end="\*/"
+# Nowdoc
+color red start="<<<'[A-Z][A-Z0-9_]*'" end="^[A-Z][A-Z0-9_]*;"

--- a/php.nanorc
+++ b/php.nanorc
@@ -37,8 +37,7 @@ color yellow "(==|===|!=|<>|!==|<=|>=|<=>)"
 # Logical Operators
 color yellow "( and | or | xor |!|&&|\|\|)"
 # And/Or/SRO/etc
-color green "(\;\;|\|\||::|=>)"
-color cyan "->"
+color cyan "(\;\;|\|\||::|=>|->)"
 # Double quoted STRINGS!
 color red "(\"[^\"]*\")"
 # Heredoc (typically ends with a semicolon).


### PR DESCRIPTION
I recently started using the font [Monoid](https://larsenwork.com/monoid/), which has ligatures for common programming symbols (`->`, `=>`, `>=`, etc). However, my terminal emulator wouldn't connect the ligatures if the syntax highlighting had them in a different color. This inspired me to update the syntax highlighting file.

Features
* boolean and null literals (true, FALSE, null, etc) are now highlighted in their own color (similar to how numbers are)
* Different types of operators have their own colors (bitwise magenta, comparison and logical yellow, assignment brightblue)
* variables are now green (yeah, this is the only subjective change made here that I care much about; since green is associated with dollars)
* braces and arrows are cyan (yes, adding another color to the palette... helps to break up variable access without blending with method calls)

```php
$object->attribute;
$array['key'];
$object->method('attribute');
```

* Initial support for nowdocs and heredocs (at least those ending in semicolons)
* Also close #286