### PR TITLE
fix script run on Ubuntu 18.04 with nano 2.9

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -12,8 +12,8 @@ _fetch_sources(){
 
   cd ~/.nano/ || exit
   unzip -o "/tmp/nanorc.zip"
-  mv nanorc-v2.9/* ./
-  rm -rf nanorc-v2.9
+  mv nanorc-2.9/* ./
+  rm -rf nanorc-2.9
   rm /tmp/nanorc.zip
 }
 


### PR DESCRIPTION
  inflating: nanorc-2.9/zsh.nanorc
    linking: nanorc-2.9/zshrc.nanorc  -> zsh.nanorc
finishing deferred symbolic links:
  nanorc-2.9/gitcommit.nanorc -> git.nanorc
  nanorc-2.9/html.j2.nanorc -> html.nanorc
  nanorc-2.9/zshrc.nanorc -> zsh.nanorc
+ mv 'nanorc-v2.9/*' ./
mv: cannot stat 'nanorc-v2.9/*': No such file or directory
+ rm -rf nanorc-v2.9
+ rm /tmp/nanorc.zip
+ '[' ']'
+ _update_nanorc
+ touch /c/Users/home/.nanorc
install.sh: line 20: /c/Users/home/.nano/nanorc: No such file or directory