### PR TITLE
Add a red highlight to YAML lines with trailing whitespace

### DIFF
--- a/yaml.nanorc
+++ b/yaml.nanorc
@@ -19,3 +19,6 @@ color brightwhite ":(\s|\t|$)"
 
 # Comments
 color brightblue "(^|[[:space:]])#.*$"
+
+# Trailing whitespace
+color ,red "[[:space:]]+$"


### PR DESCRIPTION
Trailing whitespace in YAML files is not considered legal by most linters. This additional rule visually highlights it.