### PR TITLE
Also highlight TypeScript (.ts) as JavaScript

### DIFF
--- a/javascript.nanorc
+++ b/javascript.nanorc
@@ -1,4 +1,4 @@
-syntax "JavaScript" "\.js$"
+syntax "JavaScript" "\.(js|ts)$"
 comment "//"
 color blue   "\<[-+]?([1-9][0-9]*|0[0-7]*|0x[0-9a-fA-F]+)([uU][lL]?|[lL][uU]?)?\>"
 color blue   "\<[-+]?([0-9]+\.[0-9]*|[0-9]*\.[0-9]+)([EePp][+-]?[0-9]+)?[fFlL]?"


### PR DESCRIPTION
As TypeScript extends JavaScript to add types, the basics of JavaScript still apply.
This change will parse `.ts` files as if they are JavaScript files, providing basic highlighting support.