### PR TITLE
Including mdx as part of the markdown.nanorc

### DIFF
--- a/markdown.nanorc
+++ b/markdown.nanorc
@@ -1,4 +1,4 @@
-syntax "Markdown" "\.(md|mkd|mkdn|markdown)$"
+syntax "Markdown" "\.(md|mkd|mkdn|markdown|mdx)$"
 
 # Tables (Github extension)
 color cyan ".*[ :]\|[ :].*"


### PR DESCRIPTION
Working with mdx files uses a lot of markdown's syntax highlighting (with the added benefit of JSX).

Including it as part of markdown.nanorc will make it easier to edit mdx files.