### PR TITLE
fix(hcl): only highlight keywords when they're actually keywords

### DIFF
--- a/hcl.nanorc
+++ b/hcl.nanorc
@@ -17,9 +17,9 @@ color green ":[[:space:]]*\"#[0-9abcdefABCDEF]+\""
 # Escapes.
 color green "\\\\" "\\\"" "\\[bfnrt]" "\\u[0-9abcdefABCDEF]{4})"
 # Special words.
-color green "(true|false|null|output|path|vault|description|default|value)"
+color green "\<(true|false|null|output|path|vault|description|default|value)\>"
 
-color brightgreen "(variable|terraform|resource|provider|module)"
+color brightgreen "\<(variable|terraform|resource|provider|module)\>"
 
 # Names (very unlikely to contain a quote).
 color brightblue "\"[^"]+\"[[:space:]]*:"


### PR DESCRIPTION
Currently highlighting is being done in a simple text match fashion, i.e

```
terraform {
  required_providers {
    //
  }

  vault_value {
    //
  }
}
```

In the above, `provider`, `vault`, and `value` will all be incorrectly highlighted green.

This changes that so that they're only highlighted if they're not part of "other text" (I don't know the technical terms - not been able to find a good reference guide for the syntax :/)

Sadly, there's not really a lot we can do about having attributes like `vault`, but this is still an improvement