### PR TITLE
Revised Markdown.nanorc and added jrnl.nanorc

### DIFF
--- a/jrnl.nanorc
+++ b/jrnl.nanorc
@@ -1,15 +1,13 @@
 ## Syntax highlighting for Jrnl/Markdown files.
 
 ## Original authors:  Ryan Westlund and Benno Schulenberg
-## Copy and modified:  Bruce DuPlanty
+## Copied Markdown and Modified for jrnl.sh:  Bruce DuPlanty
 ## License:  GPL version 3 or newer
 
 syntax "jrnl" "\.(jrnl)$"
 # @tag +tag #tag
 color brightgreen "\+{1}[a-zA-Z0-9_!:\-\.]*"
 color brightgreen "@{1}[a-zA-Z0-9_!:\-\.]*"
-#color brightgreen "(@+[a-zA-Z0-9\-\_\.\=\!\:(_)]{1,})"
-#color brightgreen "(\++[a-zA-Z0-9\-\_\.\=\!\:(_)]{1,})"
 color brightred "#{1}[a-zA-Z0-9_!:\-\.]*"
 
 # Tables (Github extension)

--- a/jrnl.nanorc
+++ b/jrnl.nanorc
@@ -32,12 +32,11 @@ color red "(^|[[:space:]])~~[^ ][^~]*~~"
 color brightmagenta "^(---+|===+|___+|\*\*\*+)\s*$"
 
 # headlines
-# color brightwhite "^#{1,6} .*"
 # for jrnl files whhere MD Headings maty be embedded
 color brightwhite "#{1,6} .*"
 
 # lists
-color orange   "^[[:space:]]*[\*+-] |^[[:space:]]*[0-9]+\. "
+color brightblue   "^[[:space:]]*[\*+-] |^[[:space:]]*[0-9]+\. "
 
 # leading whitespace
 color black    "^[[:space:]]+"

--- a/jrnl.nanorc
+++ b/jrnl.nanorc
@@ -1,8 +1,15 @@
-syntax "Markdown" "\.(md|mkd|mkdn|markdown)$"
+## Syntax highlighting for Jrnl/Markdown files.
 
+## Original authors:  Ryan Westlund and Benno Schulenberg
+## Copy and modified:  Bruce DuPlanty
+## License:  GPL version 3 or newer
+
+syntax "jrnl" "\.(jrnl)$"
 # @tag +tag #tag
 color brightgreen "\+{1}[a-zA-Z0-9_!:\-\.]*"
 color brightgreen "@{1}[a-zA-Z0-9_!:\-\.]*"
+#color brightgreen "(@+[a-zA-Z0-9\-\_\.\=\!\:(_)]{1,})"
+#color brightgreen "(\++[a-zA-Z0-9\-\_\.\=\!\:(_)]{1,})"
 color brightred "#{1}[a-zA-Z0-9_!:\-\.]*"
 
 # Tables (Github extension)
@@ -25,7 +32,9 @@ color red "(^|[[:space:]])~~[^ ][^~]*~~"
 color brightmagenta "^(---+|===+|___+|\*\*\*+)\s*$"
 
 # headlines
-color brightwhite "^#{1,6} .*"
+# color brightwhite "^#{1,6} .*"
+# for jrnl files whhere MD Headings maty be embedded
+color brightwhite "#{1,6} .*"
 
 # lists
 color orange   "^[[:space:]]*[\*+-] |^[[:space:]]*[0-9]+\. "
@@ -53,5 +62,5 @@ color yellow   "`[^`]*`|^ {4}[^-+*].*"
 color yellow start="^```[^$]" end="^```$"
 color yellow "^```$"
 
-## Trailing spaces
+# Trailing spaces
 color ,green "[[:space:]]+$"

--- a/markdown.nanorc
+++ b/markdown.nanorc
@@ -28,7 +28,7 @@ color brightmagenta "^(---+|===+|___+|\*\*\*+)\s*$"
 color brightwhite "^#{1,6} .*"
 
 # lists
-color orange   "^[[:space:]]*[\*+-] |^[[:space:]]*[0-9]+\. "
+color brightblue   "^[[:space:]]*[\*+-] |^[[:space:]]*[0-9]+\. "
 
 # leading whitespace
 color black    "^[[:space:]]+"


### PR DESCRIPTION
## Revised Markdown.nanorc
 * highlights `# Headings` with a hashtag and space like most MD interpreters
 * modified some colors for readability
 * added highlighting for other common user type tagging, hashes `#` `@` and `+`

## Copied Markdown.nanorc and modified to jrnl.nanorc
 * to be able to add syntax highlighting to jrnl.sh files when editing (temp files end in `.jrnl` on OSX and `.txt` on Win)
       * edit jrnl.sh config file on win with `nano -Y jrnl` for the editor line
 * allows `# Headings` highlighting embedded in lines as this is a probability in jrnl.sh created files