### PR TITLE
Fix highlighting of `${name%%pattern}` shell expansion

### DIFF
--- a/sh.nanorc
+++ b/sh.nanorc
@@ -17,7 +17,7 @@ color brightblue "\<(alias|bg|bind|break|builtin|caller|cd|command|compgen|compl
 ## not buitins:
 ## cat|chmod|chown|cp|env|grep|install|ln|make|mkdir|mv|rm|sed|tar|touch
 icolor brightgreen "^\s+[0-9A-Z_]+\s+\(\)"
-icolor brightred "\$\{?[0-9A-Z_!@#$*?-]+\}?"
+icolor brightred "\$\{?[0-9A-Z_!@#%$*?-]+\}?"
 color brightyellow ""(\\.|[^"])*"" "'(\\.|[^'])*'"
 color cyan "(^|[[:space:]])#.*$"
 color ,green "[[:space:]]+$"

--- a/zsh.nanorc
+++ b/zsh.nanorc
@@ -28,7 +28,7 @@ color brightmagenta "\<(base(32|64)|basename|cat|chcon|chgrp|chmod|chown|chroot|
 icolor brightgreen "^\s+(function\s+)[0-9A-Z_]+\s+\(\)"
 
 ## Variables
-icolor brightred "\$\{?[0-9A-Z_!@#$*?-]+\}?"
+icolor brightred "\$\{?[0-9A-Z_!@#%$*?-]+\}?"
 
 ## Strings
 color yellow ""(\\.|[^"])*""


### PR DESCRIPTION
Fixes the highlight of both `${name%pattern}` and `${name%%pattern}` variable expansion in shell files


before:
![image](https://user-images.githubusercontent.com/52980486/136033155-dbbf1bc7-8a80-4fad-9d82-f3542f3aaa38.png)

after:
![image](https://user-images.githubusercontent.com/52980486/136033020-0f31a5b0-a44e-45c8-b80d-dacadfc79593.png)
