### PR TITLE
Made etc-hosts path regex match more strict + Added shebang matching for PHP executables without extension

### DIFF
--- a/etc-hosts.nanorc
+++ b/etc-hosts.nanorc
@@ -1,5 +1,5 @@
 ## Make /etc/hosts nicer to read, see `man hosts 5` to see the format
-syntax "/etc/hosts" "hosts"
+syntax "/etc/hosts" "^/etc/hosts$"
 
 # IPv4
 color yellow "^[0-9\.]+\s"

--- a/php.nanorc
+++ b/php.nanorc
@@ -1,5 +1,6 @@
 ## PHP Syntax Highlighting
 syntax "PHP" "\.php[2345s~]?$|\.module$"
+header "^#!.*php"
 magic "PHP script"
 comment "//"
 color white start="<\?(php|=)?" end="\?>"


### PR DESCRIPTION
This got me in a lot of trouble with a file path containing /vhosts/ so I made it more strict.