### PR TITLE
Changed system-wide nano syntax-highlight path in README.md

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ The files should be placed inside of the `~/.nano/` directory.
 
 You can put the files in another directory inside the correct `.nano` folder.
 For example: `~/.nano/nanorc/`.
-For readability will use `$install_path` for the path of your choose (in *system wide* the path is always `/usr/share/nano-syntax-highlighting/`).
+For readability will use `$install_path` for the path of your choose (in *system wide* the path is always `/usr/share/nano/`[^1]).
 
 For user, only run:
 
@@ -110,3 +110,5 @@ Please see this [issue](https://savannah.gnu.org/bugs/?56994).
 ## Acknowledgements
 
 Some of these files are derived from the original [Nano](https://www.nano-editor.org) editor [repo](https://git.savannah.gnu.org/cgit/nano.git)
+
+[^1]: https://www.nano-editor.org/dist/latest/nanorc.5.html#FILES


### PR DESCRIPTION
Dear Developers,

Thank you very much for the awesome project!

Changes:

1. > Set actual path for definitions for the syntax coloring of common file types.

Tested via stracing `nano`.

<details>
  <summary>strace excerpt containing `/usr/share` only.</summary>

```bash
openat(AT_FDCWD, "/usr/share/locale/locale.alias", O_RDONLY|O_CLOEXEC) = 3
newfstatat(AT_FDCWD, "/usr/share/terminfo", {st_mode=S_IFDIR|0755, st_size=4096, ...}, 0) = 0
access("/usr/share/terminfo/x/xterm-256color", R_OK) = 0
openat(AT_FDCWD, "/usr/share/terminfo/x/xterm-256color", O_RDONLY) = 3
read(3, "lor magenta\n\n\n## === Syntax coloring ===\n## For all details, see 'man nanorc', section SYNTAX HIGHLIGHTING.\n\n## To include most of the existing syntax definitions, you can do:\ninclude \"/usr/share/nano/*.nanorc\"\n\n## Or you can select just the ones you need.  For example:\n# include \"/usr/share/nano/html.nanorc\"\n# include \"/usr/share/nano/python.nanorc\"\n# include \"/usr/share/nano/sh.nanorc\"\n\n## In /usr/share/nano/extra/ you can find some syntaxes that are\n## specific for certain distros or for some less common languages.\n\n\n## If <Tab> should always produce four spaces when editing a Python file,\n## independent of the settings of 'tabsize' and 'tabstospaces':\n# extendsyntax python tabgives \"    \"\n\n## If <Tab> should always produce an actual TAB when editing a Makefile:\n# extendsyntax makefile tabgives \"\t\"\n\n\n## === Key bindings ===\n## For all details, see 'man nanorc', section REBINDING KEYS.\n\n## If you want to suspend nano with one keystroke (instead of with ^T^Z):\n# bind ^Z suspend main\n\n## The <Ctrl+Delete> keystroke deletes the word to the right of the cursor.\n## On some terminals the <Ctrl+Backspace> keystroke produces ^H, which is\n## the ASCII character for backspace, so it is bound by default to the\n## backspace function.  The <Backspace> key itself produces a different\n## keycode, which is hard-bound to the backspace function.  So, if you\n## normally use <Backspace> for backspacing and not ^H, you can make\n## <Ctrl+Backspace> delete the word to the left of the cursor with:\n# bind ^H chopwordleft main\n\n## For a more mnemonic Comment keystroke (overriding Cut-from-cursor):\n# bind M-K comment main\n\n## If you want ^L to just refresh the screen and not center the cursor:\n# bind ^L refresh main\n\n## When you sometimes type M-J instead of M-K, or M-T instead of M-R:\n# unbind M-J main\n# unbind M-T main\n## (Those functions are still accessible through ^T^J and ^T^V.)\n\n## For quickly uppercasing or lowercasing the word under or after the cursor.\n## (These effectively select a word and pipe it through a sed command.)\n#bind Sh-M-U \"{nextword}{mark}{prevword}{execute}|sed 's/.*/\\U&/'{enter}\" main\n#bind Sh-M-L \"{nextword}{mark}{prevword}{execute}|sed 's/.*/\\L&/'{enter}\" main\n\n## For copying a marked region to the system clipboard:\n# bind Sh-M-T \"{execute}|xsel -ib{enter}{undo}\" main\n\n## For snipping trailing blanks when you save a file:\n# bind ^S \"{execute}| sed 's/\\s\\+$//' {enter}{savefile}\" main\n\n## If you would like nano to have keybindings that are more \"usual\",\n## such as ^O for Open, ^F for Find, ^H for Help, and ^Q for Quit,\n## then uncomment these:\n#bind ^X cut main\n#bind ^C copy main\n#bind ^V paste all\n#bind ^Q exit all\n#bind ^S savefile main\n#bind ^W writeout main\n#bind ^O insert main\n#set multibuffer\n#bind ^H help all\n#bind ^H exit help\n#bind ^F whereis all\n#bind ^G findnext all\n#bind ^B wherewas all\n#bind ^D findprevious all\n#bind ^R replace main\n#unbind ^U all\n#unbind ^N main\n#unbind ^Y all\n#unbind M-J main\n#unbind M-T main\n#bind ^A mark main\n#bind ^P location main\n#bind ^T gotoline main\n#bind ^T gotodir browser\n#bind ^T cutrestoffile execute\n#bind ^L linter execute\n#bind ^E execute main\n#bind ^K \"{mark}{end}{zap}\" main\n#bind ^U \"{mark}{home}{zap}\" main\n#bind ^Z undo main\n#bind ^Y redo main\n", 4096) = 3251
openat(AT_FDCWD, "/usr/share/nano", O_RDONLY|O_NONBLOCK|O_CLOEXEC|O_DIRECTORY) = 4
access("/usr/share/nano/asm.nanorc", R_OK) = 0
access("/usr/share/nano/asm.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/asm.nanorc", {st_mode=S_IFREG|0644, st_size=714, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/asm.nanorc", O_RDONLY) = 4
access("/usr/share/nano/autoconf.nanorc", R_OK) = 0
access("/usr/share/nano/autoconf.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/autoconf.nanorc", {st_mode=S_IFREG|0644, st_size=635, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/autoconf.nanorc", O_RDONLY) = 4
access("/usr/share/nano/awk.nanorc", R_OK) = 0
access("/usr/share/nano/awk.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/awk.nanorc", {st_mode=S_IFREG|0644, st_size=1339, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/awk.nanorc", O_RDONLY) = 4
access("/usr/share/nano/c.nanorc", R_OK) = 0
access("/usr/share/nano/c.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/c.nanorc", {st_mode=S_IFREG|0644, st_size=1926, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/c.nanorc", O_RDONLY) = 4
access("/usr/share/nano/changelog.nanorc", R_OK) = 0
access("/usr/share/nano/changelog.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/changelog.nanorc", {st_mode=S_IFREG|0644, st_size=790, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/changelog.nanorc", O_RDONLY) = 4
access("/usr/share/nano/cmake.nanorc", R_OK) = 0
access("/usr/share/nano/cmake.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/cmake.nanorc", {st_mode=S_IFREG|0644, st_size=824, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/cmake.nanorc", O_RDONLY) = 4
access("/usr/share/nano/css.nanorc", R_OK) = 0
access("/usr/share/nano/css.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/css.nanorc", {st_mode=S_IFREG|0644, st_size=485, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/css.nanorc", O_RDONLY) = 4
access("/usr/share/nano/debian.nanorc", R_OK) = 0
access("/usr/share/nano/debian.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/debian.nanorc", {st_mode=S_IFREG|0644, st_size=801, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/debian.nanorc", O_RDONLY) = 4
access("/usr/share/nano/default.nanorc", R_OK) = 0
access("/usr/share/nano/default.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/default.nanorc", {st_mode=S_IFREG|0644, st_size=775, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/default.nanorc", O_RDONLY) = 4
access("/usr/share/nano/elisp.nanorc", R_OK) = 0
access("/usr/share/nano/elisp.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/elisp.nanorc", {st_mode=S_IFREG|0644, st_size=1108, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/elisp.nanorc", O_RDONLY) = 4
access("/usr/share/nano/email.nanorc", R_OK) = 0
access("/usr/share/nano/email.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/email.nanorc", {st_mode=S_IFREG|0644, st_size=340, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/email.nanorc", O_RDONLY) = 4
access("/usr/share/nano/go.nanorc", R_OK) = 0
access("/usr/share/nano/go.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/go.nanorc", {st_mode=S_IFREG|0644, st_size=1446, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/go.nanorc", O_RDONLY) = 4
access("/usr/share/nano/groff.nanorc", R_OK) = 0
access("/usr/share/nano/groff.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/groff.nanorc", {st_mode=S_IFREG|0644, st_size=742, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/groff.nanorc", O_RDONLY) = 4
access("/usr/share/nano/guile.nanorc", R_OK) = 0
access("/usr/share/nano/guile.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/guile.nanorc", {st_mode=S_IFREG|0644, st_size=562, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/guile.nanorc", O_RDONLY) = 4
access("/usr/share/nano/haskell.nanorc", R_OK) = 0
access("/usr/share/nano/haskell.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/haskell.nanorc", {st_mode=S_IFREG|0644, st_size=1009, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/haskell.nanorc", O_RDONLY) = 4
access("/usr/share/nano/html.nanorc", R_OK) = 0
access("/usr/share/nano/html.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/html.nanorc", {st_mode=S_IFREG|0644, st_size=1286, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/html.nanorc", O_RDONLY) = 4
access("/usr/share/nano/java.nanorc", R_OK) = 0
access("/usr/share/nano/java.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/java.nanorc", {st_mode=S_IFREG|0644, st_size=654, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/java.nanorc", O_RDONLY) = 4
access("/usr/share/nano/javascript.nanorc", R_OK) = 0
access("/usr/share/nano/javascript.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/javascript.nanorc", {st_mode=S_IFREG|0644, st_size=822, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/javascript.nanorc", O_RDONLY) = 4
access("/usr/share/nano/json.nanorc", R_OK) = 0
access("/usr/share/nano/json.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/json.nanorc", {st_mode=S_IFREG|0644, st_size=805, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/json.nanorc", O_RDONLY) = 4
access("/usr/share/nano/lua.nanorc", R_OK) = 0
access("/usr/share/nano/lua.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/lua.nanorc", {st_mode=S_IFREG|0644, st_size=2461, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/lua.nanorc", O_RDONLY) = 4
access("/usr/share/nano/makefile.nanorc", R_OK) = 0
access("/usr/share/nano/makefile.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/makefile.nanorc", {st_mode=S_IFREG|0644, st_size=536, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/makefile.nanorc", O_RDONLY) = 4
access("/usr/share/nano/man.nanorc", R_OK) = 0
access("/usr/share/nano/man.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/man.nanorc", {st_mode=S_IFREG|0644, st_size=717, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/man.nanorc", O_RDONLY) = 4
access("/usr/share/nano/markdown.nanorc", R_OK) = 0
access("/usr/share/nano/markdown.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/markdown.nanorc", {st_mode=S_IFREG|0644, st_size=947, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/markdown.nanorc", O_RDONLY) = 4
access("/usr/share/nano/nanohelp.nanorc", R_OK) = 0
access("/usr/share/nano/nanohelp.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/nanohelp.nanorc", {st_mode=S_IFREG|0644, st_size=594, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/nanohelp.nanorc", O_RDONLY) = 4
access("/usr/share/nano/nanorc.nanorc", R_OK) = 0
access("/usr/share/nano/nanorc.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/nanorc.nanorc", {st_mode=S_IFREG|0644, st_size=4325, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/nanorc.nanorc", O_RDONLY) = 4
access("/usr/share/nano/nftables.nanorc", R_OK) = 0
access("/usr/share/nano/nftables.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/nftables.nanorc", {st_mode=S_IFREG|0644, st_size=927, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/nftables.nanorc", O_RDONLY) = 4
access("/usr/share/nano/objc.nanorc", R_OK) = 0
access("/usr/share/nano/objc.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/objc.nanorc", {st_mode=S_IFREG|0644, st_size=1487, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/objc.nanorc", O_RDONLY) = 4
access("/usr/share/nano/ocaml.nanorc", R_OK) = 0
access("/usr/share/nano/ocaml.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/ocaml.nanorc", {st_mode=S_IFREG|0644, st_size=831, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/ocaml.nanorc", O_RDONLY) = 4
access("/usr/share/nano/patch.nanorc", R_OK) = 0
access("/usr/share/nano/patch.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/patch.nanorc", {st_mode=S_IFREG|0644, st_size=600, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/patch.nanorc", O_RDONLY) = 4
access("/usr/share/nano/perl.nanorc", R_OK) = 0
access("/usr/share/nano/perl.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/perl.nanorc", {st_mode=S_IFREG|0644, st_size=2119, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/perl.nanorc", O_RDONLY) = 4
access("/usr/share/nano/php.nanorc", R_OK) = 0
access("/usr/share/nano/php.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/php.nanorc", {st_mode=S_IFREG|0644, st_size=1081, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/php.nanorc", O_RDONLY) = 4
access("/usr/share/nano/po.nanorc", R_OK) = 0
access("/usr/share/nano/po.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/po.nanorc", {st_mode=S_IFREG|0644, st_size=1181, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/po.nanorc", O_RDONLY) = 4
access("/usr/share/nano/python.nanorc", R_OK) = 0
access("/usr/share/nano/python.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/python.nanorc", {st_mode=S_IFREG|0644, st_size=1406, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/python.nanorc", O_RDONLY) = 4
access("/usr/share/nano/ruby.nanorc", R_OK) = 0
access("/usr/share/nano/ruby.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/ruby.nanorc", {st_mode=S_IFREG|0644, st_size=1343, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/ruby.nanorc", O_RDONLY) = 4
access("/usr/share/nano/rust.nanorc", R_OK) = 0
access("/usr/share/nano/rust.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/rust.nanorc", {st_mode=S_IFREG|0644, st_size=1036, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/rust.nanorc", O_RDONLY) = 4
access("/usr/share/nano/sh.nanorc", R_OK) = 0
access("/usr/share/nano/sh.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/sh.nanorc", {st_mode=S_IFREG|0644, st_size=1527, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/sh.nanorc", O_RDONLY) = 4
access("/usr/share/nano/sql.nanorc", R_OK) = 0
access("/usr/share/nano/sql.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/sql.nanorc", {st_mode=S_IFREG|0644, st_size=2406, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/sql.nanorc", O_RDONLY) = 4
access("/usr/share/nano/tcl.nanorc", R_OK) = 0
access("/usr/share/nano/tcl.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/tcl.nanorc", {st_mode=S_IFREG|0644, st_size=2133, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/tcl.nanorc", O_RDONLY) = 4
access("/usr/share/nano/tex.nanorc", R_OK) = 0
access("/usr/share/nano/tex.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/tex.nanorc", {st_mode=S_IFREG|0644, st_size=199, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/tex.nanorc", O_RDONLY) = 4
access("/usr/share/nano/texinfo.nanorc", R_OK) = 0
access("/usr/share/nano/texinfo.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/texinfo.nanorc", {st_mode=S_IFREG|0644, st_size=834, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/texinfo.nanorc", O_RDONLY) = 4
access("/usr/share/nano/xml.nanorc", R_OK) = 0
access("/usr/share/nano/xml.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/xml.nanorc", {st_mode=S_IFREG|0644, st_size=686, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/xml.nanorc", O_RDONLY) = 4
access("/usr/share/nano/yaml.nanorc", R_OK) = 0
access("/usr/share/nano/yaml.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/yaml.nanorc", {st_mode=S_IFREG|0644, st_size=1368, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/yaml.nanorc", O_RDONLY) = 4
read(3, "syntax-\n/usr/share\n/usr/share/nano/\nuser\nsyntax\nread\n\n\n\n", 4096) = 56
access("/usr/share/nano/default.nanorc", R_OK) = 0
access("/usr/share/nano/default.nanorc", R_OK) = 0
newfstatat(AT_FDCWD, "/usr/share/nano/default.nanorc", {st_mode=S_IFREG|0644, st_size=775, ...}, 0) = 0
openat(AT_FDCWD, "/usr/share/nano/default.nanorc", O_RDONLY) = 3
```
  
</details>

Best and kind regards ✨ 