### PR TITLE
Missing credits to original author @craigbarnes whose work was used i…

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -9,6 +9,7 @@ Authors are sorted by number of commits.
 * Alex Taber
 * Gareth Jones
 * Zach DeCook
+* Craig Barnes
 * Mariusz Smykuła
 * Dante Falzone
 * Michael Straube


### PR DESCRIPTION
…n the amendment https://github.com/scopatz/nanorc/pull/11

@craigbarnes sorry for missing you in the commit