### PR TITLE
Fix git nanorc

### DIFF
--- a/oz.nanorc
+++ b/oz.nanorc
@@ -1,0 +1,64 @@
+## Syntax to highlighting for Mozart2 programing system
+## See http://mozart2.org/
+
+## Original author: Mattéo Dubuisson
+## Author company : Université catholique de Louvain La Neuve
+## Year : 2025
+## License: Public domain
+
+syntax oz "\.oz$"
+magic "OZ source code"
+comment "%"
+
+# Keywords (http://mozart2.org/mozart-v1/doc-1.4.0/notation/node2.html#chapter.lexical)
+color brightmagenta "andthen|at|attr|case|catch|choice|cond|declare|define|dis|div|else|elseclause|elseif|end|export|fail|false|feat|finally|from|fun|functor|if|import|in|local|lock|meth|mod|not|of|or|orelse|prepare|proc|prop|raise|require|self|skip|suchthat|then|thread|true|try|unit"
+
+# Delimiters
+color white "\(|\)|\[|\]|\{|\}|\||\#|\:|\.\.\.|\=|\.|\:\=|\^|\[\]|\$|\!|\_|\~|\+|\-|\*|\/|\@|<\-|\,|\!\!|<\=|\=\=|\\\=|<|\=<|>|>\=|\=\:|\\\=\:|<\:|\=<\:|>\:|>\=\:|\:\:|\:\:\:"
+
+# Operators
+
+# Label
+color white "[A-Z][A-Za-z0-9]*"
+
+# Value
+color white "=[[:space:]]*[A-Za-z0-9]+"
+
+# Number
+color yellow "[[:space:]][0-9]+"
+color yellow "[0-9]+[[:space:]]"
+
+# Procedure / Function / Method / Call
+color white "\{[[A-Za-z0-9[:space:].]+\}"
+color brightcyan "\{[[:space:]]*[^[:space:]}]+"
+color brightblue "\{[[:space:]]*[^[:space:]}.]+"
+color brightmagenta "\{|\}"
+
+# Class
+color brightgreen "(class|from)[[:space:]]*[A-Za-z0-9]+"
+color brightmagenta "class|from"
+
+# Directive (http://mozart2.org/mozart-v1/doc-1.4.0/compiler/node2.html)
+color brightgreen "\\(switch|pushSwitches|popSwitches|localSwitches|line|insert|define|undef|ifdef|ifndef|else|endif)"
+
+# Record
+color cyan "[a-z][A-Za-z0-9]*\("
+color white "\("
+
+# Record key
+color yellow "[A-Za-z0-9]*:"
+color white ":"
+
+# Record value
+color cyan "\.[A-Za-z0-9]+"
+color yellow "\.[0-9]+"
+color white "\."
+
+# String
+color yellow "`([^`]|\\`)*`"
+color brightyellow "'([^']|\\')*'"
+color brightyellow ""([^"]|\\")*""
+
+# Comments
+color orange "%[^"]*$|(^|[[:blank:]])%.*"
+color orange start="/\*" end="\*/"


### PR DESCRIPTION
Hello,

I fixed a small bug https://github.com/scopatz/nanorc/issues/438 where black (not bright) things where invisible on some terminals like mine Konsole using the default theme and it could impact a lot of users. The color 'black' is a perfect match with the default background color making string looking exactly like a chain of spaces. More, when the blinking white cursor passes on it it just disappears and thus gives the impression nano has a bug. I fixed this as proposed by the author to make it cyan to resolve the issue, it's visible and appear more natural as comments with nano are often cyan I have the impression. But variable assignation lines in the .git/config were also cyan so it looked ugly so I just simply put it to white. Maybe I'm wrong but it seems to me much cleaner and readable that way I don't know what you thing ?

Commit file before :
<img width="801" height="495" alt="Screenshot_20251112_153747" src="https://github.com/user-attachments/assets/59a333cf-a17c-4787-9f9f-fd6f358a6b6c" />

Config file before :
<img width="801" height="495" alt="Screenshot_20251112_153739" src="https://github.com/user-attachments/assets/480e0331-b9e3-45de-a668-cdf1f5e3026d" />

Commit file after :
<img width="801" height="495" alt="Screenshot_20251112_153829" src="https://github.com/user-attachments/assets/f6073cfa-4865-42d7-8536-cb37049fe58a" />

Config file after :
<img width="801" height="495" alt="Screenshot_20251112_153722" src="https://github.com/user-attachments/assets/27bfe4bc-dd96-403d-878e-fde2c9c4f4f3" />

I hope it helps,
Thank you very much for you time,

